### PR TITLE
Make files public readable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ Before:
 After:
 
     <a href="https://www.facebook.com/letsHackCU" target="_blank">Visit our facebook</a>
+
+## Deployment
+
+1. Check the site to make sure that everything looks OK. Give it about 30 seconds to build.
+  - `gulp serve:dist`
+1. Make sure your `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables
+   are set. Hit up @ianks for those keys.
+1. Publish the site to production:
+  - `gulp publish`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,12 +61,14 @@ gulp.task('publish', function() {
     "distributionId": "E2EHAFBXJFNUF"
   };
 
+  var headers = {"x-amz-acl" : "public-read"}
+
   var publisher = awspublish.create(aws);
 
   return gulp.src('dist/**/*')
     .pipe(revall())
     .pipe(awspublish.gzip())
-    .pipe(parallel(publisher.publish(), os.cpus().length))
+    .pipe(parallel(publisher.publish(headers), os.cpus().length))
     .pipe(publisher.cache())
     .pipe(publisher.sync())
     .pipe(awspublish.reporter())


### PR DESCRIPTION
aws-publish was supposed to automatically set the public-read headers, by that did not work. This completes the deployment process. Now, anyone with a key for AWS can run `gulp publish` and things will automatically be deployed! Hit me up for a key.

Here's the newest version of the site served via CDN: http://d1ma16vmjy33ld.cloudfront.net/